### PR TITLE
Fix/saml-password-not-required

### DIFF
--- a/main.ts
+++ b/main.ts
@@ -85,6 +85,10 @@ function handlePluginCases(plugins: PluginInstallation[]): DSGResourceData {
 
     mockedEntities = mockedEntities.map((entity) => {
       if (entity.name === authEntityName) {
+        const passwordField = entity.fields.find(
+          (field) => field.name === "password"
+        );
+        passwordField!.required = false;
         entity.fields.push(sessionIdField);
       }
       return entity;

--- a/test-cases/postgres-saml/input.json
+++ b/test-cases/postgres-saml/input.json
@@ -47,7 +47,7 @@
           "name": "password",
           "displayName": "Password",
           "dataType": "Password",
-          "required": true,
+          "required": false,
           "unique": false,
           "searchable": true
         },
@@ -1053,22 +1053,22 @@
   "roles": [
     {
       "id": "4da76cb1-46d0-4fd0-b81b-930c0ae5ec40",
-      "createdAt": "2024-04-03T15:19:38.667Z",
-      "updatedAt": "2024-04-03T15:19:38.667Z",
+      "createdAt": "2024-04-04T09:26:01.508Z",
+      "updatedAt": "2024-04-04T09:26:01.508Z",
       "displayName": "User",
       "name": "user"
     },
     {
       "id": "4da76cb1-46d0-4fd0-b81b-930c0ae5ec41",
-      "createdAt": "2024-04-03T15:19:38.667Z",
-      "updatedAt": "2024-04-03T15:19:38.667Z",
+      "createdAt": "2024-04-04T09:26:01.508Z",
+      "updatedAt": "2024-04-04T09:26:01.508Z",
       "displayName": "Admin",
       "name": "admin"
     },
     {
       "id": "4da76cb1-46d0-4fd0-b81b-930c0ae5ec42",
-      "createdAt": "2024-04-03T15:19:38.667Z",
-      "updatedAt": "2024-04-03T15:19:38.667Z",
+      "createdAt": "2024-04-04T09:26:01.508Z",
+      "updatedAt": "2024-04-04T09:26:01.508Z",
       "displayName": "Area Manager",
       "name": "areaManager"
     }


### PR DESCRIPTION
Part of: https://github.com/amplication/private-issues/issues/167

make sure that the password field of the auth entity is not required when saml is installed